### PR TITLE
feat: 2秒ごとのポーリング機能付きグラフと一覧表示の最適化

### DIFF
--- a/apps/web/src/app/admin/events/[id]/components/PollingParticipantCharts.tsx
+++ b/apps/web/src/app/admin/events/[id]/components/PollingParticipantCharts.tsx
@@ -1,0 +1,246 @@
+'use client'
+
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { usePollingTelemetry } from '@/hooks/usePollingTelemetry'
+import { RefreshCw, Clock } from 'lucide-react'
+import { useState } from 'react'
+
+interface TelemetryData {
+  device_id: string
+  timestamp_ms: number
+  heart_rate_bpm: number | null
+  battery_pct: number | null
+}
+
+interface DeviceAssignment {
+  device_id: string
+  participant_id: string
+  profiles: {
+    nickname: string | null
+  } | null
+}
+
+interface PollingParticipantChartsProps {
+  eventId: string
+  deviceAssignments: DeviceAssignment[]
+  enabled?: boolean
+}
+
+export default function PollingParticipantCharts({ 
+  eventId, 
+  deviceAssignments, 
+  enabled = true 
+}: PollingParticipantChartsProps) {
+  const { telemetryData, isLoading, error, lastUpdate, refetch } = usePollingTelemetry({ 
+    eventId, 
+    enabled,
+    intervalMs: 2000 // 2秒ごと
+  })
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  // デバイスIDから参加者名へのマッピングを作成
+  const deviceToParticipant = new Map<string, string>()
+  deviceAssignments.forEach(assignment => {
+    const nickname = assignment.profiles?.nickname || `参加者 ${assignment.participant_id.slice(0, 8)}`
+    deviceToParticipant.set(assignment.device_id, nickname)
+  })
+
+  // 参加者ごとにデータをグループ化
+  const participantData = new Map<string, TelemetryData[]>()
+  telemetryData.forEach(data => {
+    const participantName = deviceToParticipant.get(data.device_id) || `デバイス ${data.device_id}`
+    if (!participantData.has(participantName)) {
+      participantData.set(participantName, [])
+    }
+    participantData.get(participantName)!.push(data)
+  })
+
+  // チャート用データを準備
+  const prepareChartData = (data: TelemetryData[]) => {
+    return data
+      .filter(d => d.heart_rate_bpm !== null)
+      .map(d => ({
+        time: new Date(d.timestamp_ms).toLocaleTimeString('ja-JP', { 
+          hour: '2-digit', 
+          minute: '2-digit',
+          second: '2-digit'
+        }),
+        heartRate: d.heart_rate_bpm
+      }))
+      .slice(-50) // 最新50件のみ表示
+  }
+
+  const colors = [
+    '#3B82F6', '#EF4444', '#10B981', '#F59E0B', '#8B5CF6', 
+    '#EC4899', '#06B6D4', '#84CC16', '#F97316', '#6366F1'
+  ]
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    await refetch()
+    setIsRefreshing(false)
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white shadow-sm rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-medium text-gray-900">参加者別グラフ</h2>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center text-red-600">
+              <Clock className="h-4 w-4 mr-1" />
+              <span className="text-sm">エラー</span>
+            </div>
+            <button
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="p-1 text-gray-600 hover:text-gray-900 disabled:opacity-50"
+            >
+              <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
+        </div>
+        <div className="text-center py-8 text-red-600">
+          {error}
+        </div>
+      </div>
+    )
+  }
+
+  if (participantData.size === 0) {
+    return (
+      <div className="bg-white shadow-sm rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-medium text-gray-900">参加者別グラフ</h2>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center text-blue-600">
+              <Clock className="h-4 w-4 mr-1" />
+              <span className="text-sm">2秒ごと更新中</span>
+            </div>
+            <button
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="p-1 text-gray-600 hover:text-gray-900 disabled:opacity-50"
+            >
+              <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
+        </div>
+        <div className="text-center py-8 text-gray-500">
+          {isLoading ? 'データを読み込み中...' : '表示できるデータがありません'}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">参加者別グラフ</h2>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center text-blue-600">
+            <Clock className="h-4 w-4 mr-1" />
+            <span className="text-sm">2秒ごと更新中</span>
+            {isLoading && <RefreshCw className="h-3 w-3 ml-1 animate-spin" />}
+          </div>
+          {lastUpdate && (
+            <div className="text-xs text-gray-500">
+              最終更新: {lastUpdate.toLocaleTimeString('ja-JP')}
+            </div>
+          )}
+          <button
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="p-1 text-gray-600 hover:text-gray-900 disabled:opacity-50"
+            title="データを更新"
+          >
+            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+      
+      {Array.from(participantData.entries()).map(([participantName, data], index) => {
+        const chartData = prepareChartData(data)
+        const color = colors[index % colors.length]
+        
+        if (chartData.length === 0) {
+          return (
+            <div key={participantName} className="bg-white shadow-sm rounded-lg p-6">
+              <h3 className="text-lg font-medium text-gray-900 mb-4">{participantName}</h3>
+              <div className="text-center py-8 text-gray-500">
+                心拍数データがありません
+              </div>
+            </div>
+          )
+        }
+
+        return (
+          <div key={participantName} className="bg-white shadow-sm rounded-lg p-6">
+            <h3 className="text-lg font-medium text-gray-900 mb-4">{participantName}</h3>
+            
+            {/* 心拍数グラフ */}
+            <div>
+              <h4 className="text-sm font-medium text-gray-700 mb-3">心拍数 (BPM)</h4>
+              <ResponsiveContainer width="100%" height={300}>
+                <LineChart data={chartData}>
+                  <CartesianGrid strokeDasharray="3 3" />
+                  <XAxis 
+                    dataKey="time" 
+                    fontSize={12}
+                    angle={-45}
+                    textAnchor="end"
+                    height={80}
+                  />
+                  <YAxis 
+                    domain={['dataMin - 10', 'dataMax + 10']}
+                    fontSize={12}
+                  />
+                  <Tooltip 
+                    labelFormatter={(value) => `時刻: ${value}`}
+                    formatter={(value: number) => [`${value} bpm`, '心拍数']}
+                  />
+                  <Line 
+                    type="monotone" 
+                    dataKey="heartRate" 
+                    stroke={color}
+                    strokeWidth={2}
+                    dot={{ fill: color, strokeWidth: 2, r: 3 }}
+                    activeDot={{ r: 5 }}
+                  />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* 統計情報 */}
+            <div className="mt-6 grid grid-cols-2 md:grid-cols-4 gap-4 pt-4 border-t border-gray-200">
+              <div className="text-center">
+                <div className="text-2xl font-semibold text-gray-900">
+                  {chartData.length > 0 ? Math.round(chartData.reduce((sum, d) => sum + (d.heartRate || 0), 0) / chartData.length) : '-'}
+                </div>
+                <div className="text-sm text-gray-500">平均心拍数</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-semibold text-gray-900">
+                  {chartData.length > 0 ? Math.max(...chartData.map(d => d.heartRate || 0)) : '-'}
+                </div>
+                <div className="text-sm text-gray-500">最大心拍数</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-semibold text-gray-900">
+                  {chartData.length > 0 ? Math.min(...chartData.map(d => d.heartRate || 0)) : '-'}
+                </div>
+                <div className="text-sm text-gray-500">最小心拍数</div>
+              </div>
+              <div className="text-center">
+                <div className="text-2xl font-semibold text-gray-900">
+                  {chartData.length}
+                </div>
+                <div className="text-sm text-gray-500">データ件数</div>
+              </div>
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/web/src/app/admin/events/[id]/components/PollingPeerDistanceCharts.tsx
+++ b/apps/web/src/app/admin/events/[id]/components/PollingPeerDistanceCharts.tsx
@@ -1,0 +1,309 @@
+'use client'
+
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { usePollingTelemetry } from '@/hooks/usePollingTelemetry'
+import { RefreshCw, Clock } from 'lucide-react'
+import { useState } from 'react'
+
+interface TelemetryPeerData {
+  device_id: string
+  peer_device_id: string
+  timestamp_ms: number
+  distance_m: number
+}
+
+interface DeviceAssignment {
+  device_id: string
+  participant_id: string
+  profiles: {
+    nickname: string | null
+  } | null
+}
+
+interface PollingPeerDistanceChartsProps {
+  eventId: string
+  deviceAssignments: DeviceAssignment[]
+  enabled?: boolean
+}
+
+export default function PollingPeerDistanceCharts({ 
+  eventId, 
+  deviceAssignments, 
+  enabled = true 
+}: PollingPeerDistanceChartsProps) {
+  const { telemetryPeersData, isLoading, error, lastUpdate, refetch } = usePollingTelemetry({ 
+    eventId, 
+    enabled,
+    intervalMs: 2000 // 2秒ごと
+  })
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  // デバイスIDから参加者名へのマッピングを作成
+  const deviceToParticipant = new Map<string, string>()
+  deviceAssignments.forEach(assignment => {
+    const nickname = assignment.profiles?.nickname || `参加者 ${assignment.participant_id.slice(0, 8)}`
+    deviceToParticipant.set(assignment.device_id, nickname)
+  })
+
+  // ペア毎にデータをグループ化
+  const pairData = new Map<string, TelemetryPeerData[]>()
+  telemetryPeersData.forEach(data => {
+    const participant1 = deviceToParticipant.get(data.device_id) || `デバイス ${data.device_id}`
+    const participant2 = deviceToParticipant.get(data.peer_device_id) || `デバイス ${data.peer_device_id}`
+    
+    // ペア名を一意にするため、アルファベット順にソート
+    const pairKey = [participant1, participant2].sort().join(' ⇔ ')
+    
+    if (!pairData.has(pairKey)) {
+      pairData.set(pairKey, [])
+    }
+    pairData.get(pairKey)!.push(data)
+  })
+
+  // チャート用データを準備
+  const prepareChartData = (data: TelemetryPeerData[]) => {
+    return data
+      .map(d => ({
+        time: new Date(d.timestamp_ms).toLocaleTimeString('ja-JP', { 
+          hour: '2-digit', 
+          minute: '2-digit',
+          second: '2-digit'
+        }),
+        distance: d.distance_m,
+        timestamp: d.timestamp_ms
+      }))
+      .sort((a, b) => a.timestamp - b.timestamp)
+      .slice(-100) // 最新100件のみ表示
+  }
+
+  // 全体の距離分布データを準備
+  const prepareDistributionData = () => {
+    const distances = telemetryPeersData.map(d => d.distance_m)
+    const buckets = [0, 2, 5, 10, 20, 50, 100, Infinity]
+    const bucketCounts = new Array(buckets.length - 1).fill(0)
+    const bucketLabels = ['0-2m', '2-5m', '5-10m', '10-20m', '20-50m', '50-100m', '100m+']
+
+    distances.forEach(distance => {
+      for (let i = 0; i < buckets.length - 1; i++) {
+        if (distance >= buckets[i] && distance < buckets[i + 1]) {
+          bucketCounts[i]++
+          break
+        }
+      }
+    })
+
+    return bucketLabels.map((label, index) => ({
+      range: label,
+      count: bucketCounts[index]
+    }))
+  }
+
+  const colors = [
+    '#3B82F6', '#EF4444', '#10B981', '#F59E0B', '#8B5CF6', 
+    '#EC4899', '#06B6D4', '#84CC16', '#F97316', '#6366F1'
+  ]
+
+  const distributionData = prepareDistributionData()
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true)
+    await refetch()
+    setIsRefreshing(false)
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white shadow-sm rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-medium text-gray-900">ピア距離グラフ</h2>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center text-red-600">
+              <Clock className="h-4 w-4 mr-1" />
+              <span className="text-sm">エラー</span>
+            </div>
+            <button
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="p-1 text-gray-600 hover:text-gray-900 disabled:opacity-50"
+            >
+              <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
+        </div>
+        <div className="text-center py-8 text-red-600">
+          {error}
+        </div>
+      </div>
+    )
+  }
+
+  if (pairData.size === 0) {
+    return (
+      <div className="bg-white shadow-sm rounded-lg p-6">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-medium text-gray-900">ピア距離グラフ</h2>
+          <div className="flex items-center gap-2">
+            <div className="flex items-center text-blue-600">
+              <Clock className="h-4 w-4 mr-1" />
+              <span className="text-sm">2秒ごと更新中</span>
+            </div>
+            <button
+              onClick={handleRefresh}
+              disabled={isRefreshing}
+              className="p-1 text-gray-600 hover:text-gray-900 disabled:opacity-50"
+            >
+              <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+            </button>
+          </div>
+        </div>
+        <div className="text-center py-8 text-gray-500">
+          {isLoading ? 'データを読み込み中...' : '表示できるピア距離データがありません'}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold text-gray-900">ピア距離グラフ</h2>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center text-blue-600">
+            <Clock className="h-4 w-4 mr-1" />
+            <span className="text-sm">2秒ごと更新中</span>
+            {isLoading && <RefreshCw className="h-3 w-3 ml-1 animate-spin" />}
+          </div>
+          {lastUpdate && (
+            <div className="text-xs text-gray-500">
+              最終更新: {lastUpdate.toLocaleTimeString('ja-JP')}
+            </div>
+          )}
+          <button
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="p-1 text-gray-600 hover:text-gray-900 disabled:opacity-50"
+            title="データを更新"
+          >
+            <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+      </div>
+      
+      {/* 距離分布グラフ */}
+      <div className="bg-white shadow-sm rounded-lg p-6">
+        <h3 className="text-lg font-medium text-gray-900 mb-4">距離分布</h3>
+        <ResponsiveContainer width="100%" height={300}>
+          <LineChart data={distributionData}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="range" fontSize={12} />
+            <YAxis fontSize={12} />
+            <Tooltip 
+              labelFormatter={(value) => `距離範囲: ${value}`}
+              formatter={(value: number) => [`${value}件`, '記録数']}
+            />
+            <Line 
+              type="monotone" 
+              dataKey="count" 
+              stroke="#3B82F6"
+              strokeWidth={3}
+              dot={{ fill: "#3B82F6", strokeWidth: 2, r: 4 }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
+
+      {/* ペア毎の距離推移 */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        {Array.from(pairData.entries()).map(([pairName, data], index) => {
+        const chartData = prepareChartData(data)
+        const color = colors[index % colors.length]
+        
+        if (chartData.length === 0) {
+          return null
+        }
+
+        // 統計情報を計算
+        const distances = chartData.map(d => d.distance)
+        const avgDistance = Math.round(distances.reduce((sum, d) => sum + d, 0) / distances.length * 10) / 10
+        const minDistance = Math.min(...distances)
+        const maxDistance = Math.max(...distances)
+        const closeContactCount = distances.filter(d => d <= 2).length
+
+        return (
+          <div key={pairName} className="bg-white shadow-sm rounded-lg p-4">
+            <h3 className="text-sm font-medium text-gray-900 mb-3">{pairName}</h3>
+            
+            <ResponsiveContainer width="100%" height={200}>
+              <LineChart data={chartData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis 
+                  dataKey="time" 
+                  fontSize={10}
+                  angle={-45}
+                  textAnchor="end"
+                  height={60}
+                  interval="preserveStartEnd"
+                />
+                <YAxis 
+                  domain={[0, 'dataMax + 5']}
+                  fontSize={10}
+                  width={40}
+                />
+                <Tooltip 
+                  labelFormatter={(value) => `時刻: ${value}`}
+                  formatter={(value: number) => [`${value}m`, '距離']}
+                />
+                <Line 
+                  type="monotone" 
+                  dataKey="distance" 
+                  stroke={color}
+                  strokeWidth={2}
+                  dot={false}
+                  activeDot={{ r: 3 }}
+                />
+                {/* 2m以下の警告ライン */}
+                <Line 
+                  type="monotone" 
+                  dataKey={() => 2}
+                  stroke="#EF4444"
+                  strokeWidth={1}
+                  strokeDasharray="3 3"
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+
+            {/* 統計情報 */}
+            <div className="mt-4 grid grid-cols-2 gap-2 pt-3 border-t border-gray-200">
+              <div className="text-center">
+                <div className="text-lg font-semibold text-gray-900">
+                  {avgDistance}m
+                </div>
+                <div className="text-xs text-gray-500">平均</div>
+              </div>
+              <div className="text-center">
+                <div className="text-lg font-semibold text-gray-900">
+                  {minDistance}m
+                </div>
+                <div className="text-xs text-gray-500">最短</div>
+              </div>
+              <div className="text-center">
+                <div className="text-lg font-semibold text-gray-900">
+                  {maxDistance}m
+                </div>
+                <div className="text-xs text-gray-500">最長</div>
+              </div>
+              <div className="text-center">
+                <div className={`text-lg font-semibold ${closeContactCount > 0 ? 'text-red-600' : 'text-green-600'}`}>
+                  {closeContactCount}
+                </div>
+                <div className="text-xs text-gray-500">近接</div>
+              </div>
+            </div>
+          </div>
+        )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/admin/events/[id]/page.tsx
+++ b/apps/web/src/app/admin/events/[id]/page.tsx
@@ -3,8 +3,8 @@ import { redirect } from 'next/navigation'
 import Link from 'next/link'
 import { ArrowLeft, Users, Activity, Wifi } from 'lucide-react'
 import EventStatusBadge from '../components/EventStatusBadge'
-import ParticipantCharts from './components/ParticipantCharts'
-import PeerDistanceCharts from './components/PeerDistanceCharts'
+import PollingParticipantCharts from './components/PollingParticipantCharts'
+import PollingPeerDistanceCharts from './components/PollingPeerDistanceCharts'
 
 
 export default async function AdminEventDetailPage({
@@ -103,10 +103,10 @@ export default async function AdminEventDetailPage({
           </div>
         </div>
 
-        {/* 参加者別グラフ */}
+        {/* 参加者別グラフ（2秒ごと更新） */}
         <div className="mb-8">
-          <ParticipantCharts 
-            telemetryData={telemetryData || []} 
+          <PollingParticipantCharts 
+            eventId={id}
             deviceAssignments={(deviceAssignments || []).map(assignment => ({
               device_id: assignment.device_id,
               participant_id: assignment.participant_id,
@@ -114,13 +114,14 @@ export default async function AdminEventDetailPage({
                 ? assignment.profiles[0] || { nickname: null }
                 : assignment.profiles
             }))}
+            enabled={true} // 常に有効にして初期表示とポーリングを両方行う
           />
         </div>
 
-        {/* ピア距離グラフ */}
+        {/* ピア距離グラフ（2秒ごと更新） */}
         <div className="mb-8">
-          <PeerDistanceCharts 
-            telemetryPeersData={telemetryPeersData || []} 
+          <PollingPeerDistanceCharts 
+            eventId={id}
             deviceAssignments={(deviceAssignments || []).map(assignment => ({
               device_id: assignment.device_id,
               participant_id: assignment.participant_id,
@@ -128,6 +129,7 @@ export default async function AdminEventDetailPage({
                 ? assignment.profiles[0] || { nickname: null }
                 : assignment.profiles
             }))}
+            enabled={true} // 常に有効にして初期表示とポーリングを両方行う
           />
         </div>
 
@@ -140,7 +142,7 @@ export default async function AdminEventDetailPage({
                 <h2 className="text-lg font-medium text-gray-900">テレメトリーデータ</h2>
               </div>
               <p className="mt-1 text-sm text-gray-600">
-                心拍数情報 (最新100件)
+                心拍数情報 (最新10件)
               </p>
             </div>
             <div className="p-6">
@@ -161,7 +163,7 @@ export default async function AdminEventDetailPage({
                       </tr>
                     </thead>
                     <tbody>
-                      {telemetryData.map((data, index) => (
+                      {telemetryData.slice(-10).map((data, index) => (
                         <tr key={index} className="border-b border-gray-100">
                           <td className="py-2 text-gray-900">{data.device_id}</td>
                           <td className="py-2 text-gray-600">
@@ -193,7 +195,7 @@ export default async function AdminEventDetailPage({
                 <h2 className="text-lg font-medium text-gray-900">ピア距離データ</h2>
               </div>
               <p className="mt-1 text-sm text-gray-600">
-                デバイス間の距離情報 (最新100件)
+                デバイス間の距離情報 (最新10件)
               </p>
             </div>
             <div className="p-6">
@@ -215,7 +217,7 @@ export default async function AdminEventDetailPage({
                       </tr>
                     </thead>
                     <tbody>
-                      {telemetryPeersData.map((data, index) => (
+                      {telemetryPeersData.slice(0, 10).map((data, index) => (
                         <tr key={index} className="border-b border-gray-100">
                           <td className="py-2 text-gray-900">{data.device_id}</td>
                           <td className="py-2 text-gray-900">{data.peer_device_id}</td>

--- a/apps/web/src/hooks/usePollingTelemetry.ts
+++ b/apps/web/src/hooks/usePollingTelemetry.ts
@@ -1,0 +1,129 @@
+'use client'
+
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { createClient } from '@supabase/supabase-js'
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+const supabase = createClient(supabaseUrl, supabaseAnonKey)
+
+interface TelemetryData {
+  device_id: string
+  timestamp_ms: number
+  heart_rate_bpm: number | null
+  battery_pct: number | null
+}
+
+interface TelemetryPeerData {
+  device_id: string
+  peer_device_id: string
+  timestamp_ms: number
+  distance_m: number
+}
+
+interface UsePollingTelemetryProps {
+  eventId: string
+  enabled?: boolean
+  intervalMs?: number
+}
+
+export function usePollingTelemetry({ 
+  eventId, 
+  enabled = true, 
+  intervalMs = 2000 
+}: UsePollingTelemetryProps) {
+  const [telemetryData, setTelemetryData] = useState<TelemetryData[]>([])
+  const [telemetryPeersData, setTelemetryPeersData] = useState<TelemetryPeerData[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [lastUpdate, setLastUpdate] = useState<Date | null>(null)
+
+  // データ取得関数
+  const fetchData = useCallback(async () => {
+    if (!enabled || !eventId) return
+
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      // テレメトリーデータを取得
+      const { data: telemetry, error: telemetryError } = await supabase
+        .from('telemetry')
+        .select('*')
+        .eq('event_id', eventId)
+        .order('timestamp_ms', { ascending: true })
+
+      if (telemetryError) {
+        console.error('Telemetry fetch error:', telemetryError)
+        setError('テレメトリーデータの取得に失敗しました')
+        return
+      }
+
+      // テレメトリーピアデータを取得
+      const { data: telemetryPeers, error: telemetryPeersError } = await supabase
+        .from('telemetry_peers')
+        .select('*')
+        .eq('event_id', eventId)
+        .order('timestamp_ms', { ascending: false })
+        .limit(100)
+
+      if (telemetryPeersError) {
+        console.error('Telemetry peers fetch error:', telemetryPeersError)
+        setError('ピア距離データの取得に失敗しました')
+        return
+      }
+
+      setTelemetryData(telemetry || [])
+      setTelemetryPeersData(telemetryPeers || [])
+      setLastUpdate(new Date())
+    } catch (err) {
+      console.error('Data fetch error:', err)
+      setError('データの取得中にエラーが発生しました')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [eventId, enabled])
+
+  // 初期データ取得
+  useEffect(() => {
+    if (enabled && eventId) {
+      fetchData()
+    }
+  }, [eventId, enabled, fetchData])
+
+  // ポーリング設定
+  useEffect(() => {
+    if (!enabled || !eventId) return
+
+    const interval = setInterval(() => {
+      fetchData()
+    }, intervalMs)
+
+    return () => {
+      clearInterval(interval)
+    }
+  }, [enabled, eventId, intervalMs, fetchData])
+
+  // メモ化された統計情報
+  const stats = useMemo(() => {
+    const telemetryCount = telemetryData.length
+    const telemetryPeersCount = telemetryPeersData.length
+    const activeDevices = new Set(telemetryData.map(d => d.device_id)).size
+    
+    return {
+      telemetryCount,
+      telemetryPeersCount,
+      activeDevices
+    }
+  }, [telemetryData, telemetryPeersData])
+
+  return {
+    telemetryData,
+    telemetryPeersData,
+    isLoading,
+    error,
+    lastUpdate,
+    stats,
+    refetch: fetchData
+  }
+}

--- a/packages/db/node_modules/.bin/drizzle-kit
+++ b/packages/db/node_modules/.bin/drizzle-kit
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/home/emi/work/private/love-sports/node_modules/.pnpm/drizzle-kit@0.31.4/node_modules/drizzle-kit/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/drizzle-kit@0.31.4/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/home/mackey/work/love-sports/node_modules/.pnpm/drizzle-kit@0.31.5/node_modules/drizzle-kit/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/drizzle-kit@0.31.5/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/home/emi/work/private/love-sports/node_modules/.pnpm/drizzle-kit@0.31.4/node_modules/drizzle-kit/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/drizzle-kit@0.31.4/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/home/mackey/work/love-sports/node_modules/.pnpm/drizzle-kit@0.31.5/node_modules/drizzle-kit/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/drizzle-kit@0.31.5/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../drizzle-kit/bin.cjs" "$@"

--- a/packages/db/node_modules/.bin/tsc
+++ b/packages/db/node_modules/.bin/tsc
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsc" "$@"

--- a/packages/db/node_modules/.bin/tsserver
+++ b/packages/db/node_modules/.bin/tsserver
@@ -10,9 +10,9 @@ case `uname` in
 esac
 
 if [ -z "$NODE_PATH" ]; then
-  export NODE_PATH="/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/node_modules"
+  export NODE_PATH="/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/node_modules"
 else
-  export NODE_PATH="/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/emi/work/private/love-sports/node_modules/.pnpm/node_modules:$NODE_PATH"
+  export NODE_PATH="/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/bin/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules/typescript/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/typescript@5.9.2/node_modules:/home/mackey/work/love-sports/node_modules/.pnpm/node_modules:$NODE_PATH"
 fi
 if [ -x "$basedir/node" ]; then
   exec "$basedir/node"  "$basedir/../typescript/bin/tsserver" "$@"

--- a/packages/db/node_modules/drizzle-kit
+++ b/packages/db/node_modules/drizzle-kit
@@ -1,1 +1,1 @@
-../../../node_modules/.pnpm/drizzle-kit@0.31.4/node_modules/drizzle-kit
+../../../node_modules/.pnpm/drizzle-kit@0.31.5/node_modules/drizzle-kit


### PR DESCRIPTION
- リアルタイム機能を削除してシンプルなポーリング方式に変更
- 2秒ごとにデータを自動取得してグラフを更新
- 初期表示時にデータを取得してグラフを表示
- テレメトリーデータとピア距離データの一覧を直近10件に制限
- ローディング状態と最終更新時刻の表示
- 手動更新ボタンの追加
- パフォーマンス最適化（データ件数制限、メモ化）